### PR TITLE
Malloc error in ft_strdup

### DIFF
--- a/get_next_line/get_next_line.c
+++ b/get_next_line/get_next_line.c
@@ -29,8 +29,8 @@ void	ft_strcpy(char *dst, const char *src)
 
 char	*ft_strdup(const char *src)
 {
-	char	*dst = malloc(len);
 	size_t	len = ft_strlen(src) + 1;
+	char	*dst = malloc(len);
 	
 	if (dst == NULL)
 		return (NULL);


### PR DESCRIPTION
↩️ Inverse the following line in ft_strdup to malloc(len) :

char	*dst = malloc(len);
size_t	len = ft_strlen(src) + 1;

✅ Become :

size_t	len = ft_strlen(src) + 1;
char	*dst = malloc(len);