### PR TITLE
Added space at end of ... in ft_printf declaration

### DIFF
--- a/ft_printf/ft_printf.c
+++ b/ft_printf/ft_printf.c
@@ -23,7 +23,7 @@ void	put_digit(long long int number, int base, int *length)
 	*length += write(1, &hexadecimal[number % base], 1);
 }
 
-int	ft_printf(const char *format, ...)
+int	ft_printf(const char *format, ... )
 {
 	int length = 0;
 


### PR DESCRIPTION
Corrected from:
```
int    ft_printf(const char *format, ...)
```
To:
```
int    ft_printf(const char *format, ... )
```

This way the code should pass the Exam Rank 03. This error was not detected by grademe.fr.