### PR TITLE
Removed unused or redundant lines on get_next_line.h

### DIFF
--- a/get_next_line/get_next_line.h
+++ b/get_next_line/get_next_line.h
@@ -7,7 +7,3 @@
 #ifndef BUFFER_SIZE
 # define BUFFER_SIZE 42
 #endif
-
-char	*get_next_line(int fd);
-
-#endif


### PR DESCRIPTION
While reviewing the get_next_line.h header file, I identified unnecessary lines of code after "endif"