### PR TITLE
correct negative number for hex to unsigned int

### DIFF
--- a/ft_printf/ft_printf.c
+++ b/ft_printf/ft_printf.c
@@ -14,11 +14,13 @@ int putstr(char *str, int i)
 int putnum(long num, int base)
 {
 	char *b = "0123456789abcdef";
-	if (num < 0)
-		return write(1, "-", 1) + putnum(num * -1, base);
-	if (num / base == 0)
-		return write(1, &b[num % base], 1);
-	return putnum(num / base, base) + putnum(num % base, base);
+	if (num <0 && base == 10)
+		return write(1, "-", 1) + putnum(num*-1, base);
+	if (num <0 && base == 16)
+		return putnum((unsigned int)num, base);
+	if (num/base==0)
+		return write(1, &b[num%base], 1);
+	return putnum(num/base, base) + putnum(num%base, base);
 }
 
 int ptf(char *s, va_list args, int i, int n)


### PR DESCRIPTION
Fixing issue ft_printf printing - in incorrect place #25 

I forget to read the exact detail of Hexadecimal conversion.. When the number given is negative and base is 16, the number input has to be cast to unsigned int according to man instead of just multiplying by -1 and adding '-' in front.

In addition, i have checked with tester (https://github.com/Tripouille/printfTester). It is able to pass all the s,d and x test. 
The code also passed test in https://grademe.fr/
