### PR TITLE
Fix buffer boundary check in GNL

### DIFF
--- a/get_next_line/get_next_line.c
+++ b/get_next_line/get_next_line.c
@@ -40,7 +40,7 @@ char	*get_next_line(int fd)
 				break ;
 		}
 		line[i++] = buffer[buffer_pos++];
-		if (buffer[buffer_pos] == '\n')
+		if (buffer[buffer_pos - 1] == '\n' || i >= sizeof(line) - 1)
 			break ;
 	}
 	line[i] = '\0';


### PR DESCRIPTION
The condition if (buffer[buffer_pos] == '\n') can sometimes cause problems because it might check data outside the buffer, especially when buffer_pos reaches the end of the buffer (buffer_read).

Changing it to if (buffer[buffer_pos - 1] == '\n' || i >= sizeof(line) - 1) is safer because it avoids accessing memory outside the buffer and it works correctly by checking the last character added to the line, making sure everything stays within bounds.